### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,9 @@ on:
   release:
     types: [created]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: build ${{ matrix.target }}


### PR DESCRIPTION
Potential fix for [https://github.com/byrdocs/byrdocs-logs-exporter/security/code-scanning/1](https://github.com/byrdocs/byrdocs-logs-exporter/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Since the workflow is related to releases, it likely requires `contents: read` and possibly `contents: write` for creating release assets. However, we will start with minimal permissions (`contents: read`) and adjust if necessary.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or within the specific job (`build`) to limit permissions to that job only. In this case, adding it at the root level is sufficient.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
